### PR TITLE
Gdal compatibilty 

### DIFF
--- a/multiply_inference_engine/inference_engine.py
+++ b/multiply_inference_engine/inference_engine.py
@@ -1,5 +1,8 @@
 import argparse
-import gdal
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 import glob
 import json
 import logging

--- a/multiply_inference_engine/inference_engine.py
+++ b/multiply_inference_engine/inference_engine.py
@@ -8,7 +8,12 @@ import json
 import logging
 import numpy as np
 import os
-import osr
+
+try:
+    from osgeo import osr
+except ImportError:
+    import osr
+
 import scipy.sparse as sp
 
 from multiply_inference_engine.inference_prior import InferencePrior

--- a/multiply_inference_engine/inference_prior.py
+++ b/multiply_inference_engine/inference_prior.py
@@ -3,7 +3,10 @@ from datetime import datetime
 from multiply_core.util import reproject_image, block_diag
 from multiply_prior_engine import PriorEngine
 from typing import List, Union
-import gdal
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 import logging
 import numpy as np
 import os


### PR DESCRIPTION
To use Gdal 3.5.1 we add:
```python 
from osgeo import gdal
```
For previous versions we add:
```python 
 import gdal
```
To be compatible with both versions we replace:
```python 
try: 
  from osgeo import gdal
except ImportError: 
  import gdal
```
